### PR TITLE
Fix broken package imports and normalize MRPConfig collection types

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,1 @@
-ÿþ
+"""Top-level package for the MRP Critical Items Analyzer."""

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -1,1 +1,1 @@
-ÿþ
+"""Core modules for MRP analysis."""

--- a/src/core/mrp_analyzer.py
+++ b/src/core/mrp_analyzer.py
@@ -32,18 +32,18 @@ logger = logging.getLogger(__name__)
 @dataclass
 class MRPConfig:
     """Configuration settings for MRP analysis."""
-    REQUIRED_COLUMNS: List[str] = (
+    REQUIRED_COLUMNS: List[str] = [
         "CÓD", "DESCRIÇÃOPROMOB", "ESTQ10", "ESTQ20", "DEMANDAMRP",
         "ESTOQSEG", "FORNECEDORPRINCIPAL", "PEDIDOS", "OBS"
-    )
-    NUMERIC_COLUMNS: List[str] = (
+    ]
+    NUMERIC_COLUMNS: List[str] = [
         "ESTQ10", "ESTQ20", "DEMANDAMRP", "ESTOQSEG", "PEDIDOS"
-    )
-    OUTPUT_COLUMNS: List[str] = (
+    ]
+    OUTPUT_COLUMNS: List[str] = [
         "CÓD", "FORNECEDOR PRINCIPAL", "DESCRIÇÃOPROMOB", "ESTQ10", "ESTQ20",
         "DEMANDAMRP", "ESTOQSEG", "PEDIDOS", "ESTOQUE DISPONÍVEL",
         "QUANTIDADE A SOLICITAR", "OBS"
-    )
+    ]
     HISTORY_DIR: str = "historico_mrp"
     
 class ValidationError(Exception):

--- a/src/exporters/__init__.py
+++ b/src/exporters/__init__.py
@@ -1,1 +1,1 @@
-ÿþ
+"""Export helpers for the MRP analyzer."""

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,1 +1,1 @@
-ÿþ
+"""Utility helpers for the MRP analyzer."""

--- a/src/validators/__init__.py
+++ b/src/validators/__init__.py
@@ -1,1 +1,1 @@
-ÿþ
+"""Validation helpers for the MRP analyzer."""


### PR DESCRIPTION
### Motivation
- Tests were failing during collection because several `__init__.py` files were effectively corrupted (UTF-16 BOM-only) which prevented Python from importing the `src` packages.  
- `MRPConfig` declared collection fields with `List[str]` type hints but used tuple literals, a mismatch that can cause unexpected behavior and fails some type-based expectations.

### Description
- Replaced corrupted `__init__.py` files with valid UTF-8 module docstrings in `src/__init__.py`, `src/core/__init__.py`, `src/utils/__init__.py`, `src/validators/__init__.py`, and `src/exporters/__init__.py` so the `src` package imports correctly.  
- Converted `REQUIRED_COLUMNS`, `NUMERIC_COLUMNS`, and `OUTPUT_COLUMNS` in `src/core/mrp_analyzer.py` from tuple literals to lists to match the `List[str]` type hints.  
- Performed minor cleanups to normalize the module files and ensure imports resolve during test collection.

### Testing
- Ran `PYTHONPATH=. pytest -q`; initial run failed with import errors due to corrupted `__init__.py` files, which prompted the `__init__.py` fixes.  
- Re-ran `PYTHONPATH=. pytest -q` after fixes and test collection now reaches module imports but fails at import of third-party dependencies because `pandas` is not installed.  
- Attempted `pip install -r requirements/dev.txt` to install test dependencies but the installation failed due to network/proxy restrictions (environment returned `403 Forbidden`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7596d171c83239a6a033acf6ae5c4)